### PR TITLE
Remove link to jake@bestow.co on sidebar

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5,7 +5,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
   - shell
 
 toc_footers:
-  - <a href='mailto:jake@bestow.co'>Sign Up for a Developer Key</a>
+  - Contact your business development <br> manager to get an API key.
 
 search: true
 ---


### PR DESCRIPTION
Remove `mailto:jake@bestow.co` link from sidebar.
Replaced with generic "contact your bus. manager" text (same one thats used in the content)


**Before**
![image](https://user-images.githubusercontent.com/54546611/86625110-2546a400-bf8a-11ea-8199-3a397e628872.png)

**After**
![image](https://user-images.githubusercontent.com/54546611/86625076-1a8c0f00-bf8a-11ea-8649-bf6f494bfd0c.png)
