### PR TITLE
Remove 2019+ param language

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -132,7 +132,7 @@ curl -X POST \
 `POST https://api.hellobestow.com/v2/quote`
 
 
-### Query Parameters
+### `POST` Body Parameters
 
 | Parameter       | Required | Description                                                             |
 | --------------- | -------- | ----------------------------------------------------------------------- |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -129,9 +129,7 @@ curl -X POST \
 
 ### HTTP Request
 
-`POST https://api.hellobestow.com/v2/quote?enable_2019_plus=true`
-
-*Note: We are temporarily using an additional parameter - enable_2019_plus - which enables the newest version of our application. You can optionally set this parameter to false if you have not yet integrated the new product codes into your code. You can also choose to leave the "enable_2019_plus" parameter out, which will return the same values as if it were set to false.
+`POST https://api.hellobestow.com/v2/quote`
 
 
 ### Query Parameters


### PR DESCRIPTION
Removed the 2019+ parameter language from the doc as it was deprecated.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->